### PR TITLE
Use fed_branch in message fields

### DIFF
--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -49,7 +49,7 @@ def setMessageFields(String messageType) {
     // add it below per the existing examples.
 
     def messageProperties = [
-            branch           : env.branch,
+            branch           : env.fed_branch,
             build_id         : env.BUILD_ID,
             build_url        : env.JENKINS_URL + 'blue/organizations/jenkins/' + env.JOB_NAME + '/detail/' + env.JOB_NAME + '/' + env.BUILD_NUMBER + '/pipeline/',
             namespace        : env.fed_namespace,


### PR DESCRIPTION
We overwrite branch with both master and rawhide, but fed_branch is always master so use that in messages