### PR TITLE
fixing typo in git repo declaration so project will deploy

### DIFF
--- a/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
+++ b/config/s2i/jenkins/jenkins-persistent-buildconfig-template.yaml
@@ -233,7 +233,7 @@ parameters:
 - description: Git source URI for Jenkins S2I
   name: REPO_URL
   required: true
-  value: https://github.com/CentOS-PaaS-SIG/fedora-upstream-pipeline.git
+  value: https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git
 - description: Git branch/tag reference
   name: REPO_REF
   value: master


### PR DESCRIPTION
typo fix for repo URL in the jenkins master template