### PR TITLE
build job is now dependent on the ci_message

### DIFF
--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -64,7 +64,8 @@ node() {
                         packagepipelineUtils.timedPipelineStep(stepName: stepName, debug: true) {
 
                             build job: "fedora-${env.branch}-build-pipeline",
-                                    parameters: [string(name: 'PROVIDED_KOJI_TASKID', value: env.fed_task_id)],
+                                    parameters: [string(name: 'PROVIDED_KOJI_TASKID', value: env.fed_task_id),
+                                                 string(name: 'CI_MESSAGE', value: env.CI_MESSAGE)],
                                     wait: false
                         }
                     }


### PR DESCRIPTION
Since pulling the branch logic out of the pull_old_task, koji builds depends on either providing the ci_message or passing in fed_branch, branch and fed_repo.