### PR TITLE
Only primary koji instance

### DIFF
--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -59,13 +59,15 @@ node() {
                     pipelineUtils.setBuildDisplayAndDescription()
                     testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
                     targetBranch = packagepipelineUtils.checkBranch()
+                    // Ensure message is from primary koji instance
+                    primaryKoji = fed_instance == "primary"
                     pipelineUtils.initializeAuditFile(msgAuditFile)
 
                 }
 
             }
 
-            if (targetBranch && testsExist) {
+            if (targetBranch && testsExist && primaryKoji) {
                 messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build')
                 pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
                 stepName = 'schedule build'


### PR DESCRIPTION
There are s390x and ppc koji instances. The build ids and task ids here are on their own count, so we don't want to trigger off of a build from that instance and query from the primary instance. We should ignore the other instances for a while.. adding functionality to work with them is not on our near term road map afaik