### PR TITLE
Add ability for upstream build pipeline to run on scratch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,8 @@ timestamps {
 
     // Task ID to bypass rpm build and grab artifacts from koji
     env.PROVIDED_KOJI_TASKID = env.PROVIDED_KOJI_TASKID ?: ''
+    // Default to build being scratch, will be overridden if triggered by nonscratch build
+    env.isScratch = true
 
     // Needed for podTemplate()
     env.SLAVE_TAG = env.SLAVE_TAG ?: 'stable'
@@ -199,6 +201,13 @@ timestamps {
                                     // Scratch build messages store things in info
                                     pipelineUtils.repoFromRequest(env.fed_request_0 ?: env.fed_info_request_0, "fed")
                                     pipelineUtils.setBuildBranch(env.fed_request_1 ?: env.fed_info_request_1, "fed")
+                                    // Use message bus format to determine if scratch build
+                                    String scratchTag = ""
+                                    env.isScratch = false
+                                    if (env.fed_info_request_0) {
+                                        scratchTag = ":S"
+                                        env.isScratch = true
+                                    }
                                 }
 
 
@@ -258,13 +267,6 @@ timestamps {
                             }
 
                             if (env.PROVIDED_KOJI_TASKID?.trim()) {
-                                // Use message bus format to determine if scratch build
-                                String scratchTag = ""
-                                env.isScratch = false
-                                if (env.fed_info_request_0) {
-                                    scratchTag = ":S"
-                                    env.isScratch = true
-                                }
                                 // Decorate our build to not be null now
                                 String buildName = "${env.koji_task_id}${scratchTag}:${env.nvr}"
                                 pipelineUtils.setCustomBuildNameAndDescription(buildName, buildName)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,8 +196,9 @@ timestamps {
                                 } else {
                                     env.artifact = 'build'
                                     pipelineUtils.flattenJSON('fed', env.CI_MESSAGE)
-                                    pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')
-                                    pipelineUtils.setBuildBranch(env.fed_request_1, "fed")
+                                    // Scratch build messages store things in info
+                                    pipelineUtils.repoFromRequest(env.fed_request_0 ?: env.fed_info_request_0, "fed")
+                                    pipelineUtils.setBuildBranch(env.fed_request_1 ?: env.fed_info_request_1, "fed")
                                 }
 
 
@@ -257,8 +258,15 @@ timestamps {
                             }
 
                             if (env.PROVIDED_KOJI_TASKID?.trim()) {
+                                // Use message bus format to determine if scratch build
+                                String scratchTag = ""
+                                env.isScratch = false
+                                if (env.fed_info_request_0) {
+                                    scratchTag = ":S"
+                                    env.isScratch = true
+                                }
                                 // Decorate our build to not be null now
-                                String buildName = "${env.koji_task_id}:${env.nvr}"
+                                String buildName = "${env.koji_task_id}${scratchTag}:${env.nvr}"
                                 pipelineUtils.setCustomBuildNameAndDescription(buildName, buildName)
                             }
 

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -29,7 +29,7 @@ timestamps {
                     ),
                     pipelineTriggers(
                             [
-                                    [$class: 'CIBuildTrigger', checks: [[expectedValue: '1', field: 'new']], providerName: 'fedora-fedmsg', selector: 'topic = "org.fedoraproject.prod.buildsys.build.state.change"']]
+                                    [$class: 'CIBuildTrigger', checks: [[expectedValue: '1', field: 'new']], providerName: 'fedora-fedmsg', selector: 'topic = "org.fedoraproject.prod.buildsys.build.state.change" OR topic = "org.fedoraproject.prod.buildsys.task.state.change']]
                     )
             ]
     )
@@ -54,6 +54,9 @@ timestamps {
                         print "CI_MESSAGE"
                         print CI_MESSAGE
                         pipelineUtils.flattenJSON('fed', env.CI_MESSAGE)
+                        # Get request vars from scratch messages
+                        env.fed_request_0 = env.fed_request_0 ?: env.fed_info_request_0
+                        env.fed_request_1 = env.fed_request_1 ?: env.fed_info_request_1
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
@@ -85,7 +88,8 @@ timestamps {
                             packagepipelineUtils.timedPipelineStep(stepName: stepName, debug: true) {
 
                                 build job: "fedora-${env.branch}-build-pipeline",
-                                        parameters: [string(name: 'PROVIDED_KOJI_TASKID', value: env.fed_task_id),
+                                        // Scratch messages from task.state.changed call it id, not task_id
+                                        parameters: [string(name: 'PROVIDED_KOJI_TASKID', value: env.fed_task_id ?: env.fed_id),
                                                      string(name: 'CI_MESSAGE', value: env.CI_MESSAGE)],
                                         wait: false
                             }

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -54,14 +54,24 @@ timestamps {
                         print "CI_MESSAGE"
                         print CI_MESSAGE
                         pipelineUtils.flattenJSON('fed', env.CI_MESSAGE)
-                        # Get request vars from scratch messages
+                        // Get request vars from scratch messages
                         env.fed_request_0 = env.fed_request_0 ?: env.fed_info_request_0
                         env.fed_request_1 = env.fed_request_1 ?: env.fed_info_request_1
+                        // Determine if scratch build
+                        env.isScratch = false
+                        if (env.fed_info_request_0) {
+                            env.isScratch = true
+                        }
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
                             pipelineUtils.setBuildBranch(env.fed_request_1, "fed")
                             targetBranch = packagepipelineUtils.checkBranch()
+                        }
+                        // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run
+                        if (env.fed_owner == "bpeck/jenkins-continuous-infra.apps.ci.centos.org") {
+                            print("This build is for a scratch build from the PR pipeline. Not triggering.")
+                            targetBranch = false
                         }
                         if (targetBranch) {
                             pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Below are the different message types that we listen and publish.  There will be
   - ex. 1234
 * ref - Indication of what we are building distro/branch/arch/distro_type
   - ex. x86_64
+* scratch - Is this message for a scratch build?
+  - ex. false
 * msgJson - A full dump of the message properties in one field of JSON
 
 
@@ -217,7 +219,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -254,7 +257,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -291,7 +295,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -329,7 +334,8 @@ email=jchaloup@redhat.com
     "type": "qcow2", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -367,7 +373,8 @@ email=jchaloup@redhat.com
     "type": "''", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -405,7 +412,8 @@ email=jchaloup@redhat.com
     "type": "qcow2", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -442,7 +450,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -479,7 +488,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -516,7 +526,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -553,7 +564,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": false
   }
 }
 ````
@@ -590,7 +602,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -627,7 +640,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -664,7 +678,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -702,7 +717,8 @@ email=jchaloup@redhat.com
     "type": "qcow2", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -740,7 +756,8 @@ email=jchaloup@redhat.com
     "type": "''", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -778,7 +795,8 @@ email=jchaloup@redhat.com
     "type": "qcow2", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -815,7 +833,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -852,7 +871,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -889,7 +909,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````
@@ -926,7 +947,8 @@ email=jchaloup@redhat.com
     "branch": "master", 
     "test_guidance": "''", 
     "comment_id": "1234",
-    "ref": "x86_64"
+    "ref": "x86_64",
+    "scratch": true
   }
 }
 ````

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -55,6 +55,7 @@ def setMessageFields(String messageType, String artifact) {
             nvr              : env.nvr,
             original_spec_nvr: env.original_spec_nvr,
             ref              : env.basearch,
+            scratch          : env.isScratch ? env.isScratch.toBoolean() : "",
             repo             : env.fed_repo,
             rev              : (artifact == 'build') ? "kojitask-${env.fed_task_id}" : env.fed_rev,
             status           : currentBuild.currentResult,


### PR DESCRIPTION
1) This will vastly increase the load. Not saying it is a bad thing, just pointing it out.
2) We will get a bunch more request[0] fields coming in now, so I think it will just be a process of fixing them as they fail until we are able to parse most of them.
3) Scratch messages come on a different topic and have ['info']['request'] instead of just ['request']. You can see how I did it. I don't love it. I don't think checking if a variable is there and if not use something else is a good solution, but it is a solution. I am open to smarter ideas.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>