### PR TITLE
Don't save the qcow2 images twice

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,7 +404,7 @@ timestamps {
                         if (currentBuild.result == 'SUCCESS') {
                             step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/job.props,**/job.props.groovy,**/*.example,**/*.qcow2', fingerprint: true])
                         } else {
-                            step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*,**/*.qcow2', excludes: '**/job.props,**/job.props.groovy,**/*.example', fingerprint: true])
+                            step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*,**/*.qcow2', excludes: '**/job.props,**/job.props.groovy,**/*.example,artifacts.ci.centos.org/**', fingerprint: true])
                         }
 
                         // Set our message topic, properties, and content


### PR DESCRIPTION
We are archiving artifacts.ci.centos.org/artifacts/fedora-atomic/pipeline/rawhide/images/*.qcow2
See https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-rawhide-build-pipeline/533/artifact/
We already save qcow2 images in images/
Saving it in two places makes up fill up storage twice as quick (the master was full this morning)
Unless someone has a reason not to, let's exclude this artifacts.ci.centos.org dir from the artifacts.