### PR TITLE
Better setting of stage fedmsg

### DIFF
--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -126,7 +126,7 @@ def setDefaultEnvVars(Map envMap=null){
     // We also set dataGrepperUrl which is needed for message tracking
     // and the correct jms-messaging message provider
 
-    if (env.ghprbActualCommit != null && env.ghprbActualCommit != "master") {
+    if (env.ghprbActualCommit != null && (env.ghprbActualCommit != "master" || env.ghprbGhRepository == "CentOS-PaaS-SIG/upstream-fedora-pipeline")) {
         env.MAIN_TOPIC = env.MAIN_TOPIC ?: 'org.centos.stage'
         env.dataGrepperUrl = 'https://apps.stg.fedoraproject.org/datagrepper'
         env.MSG_PROVIDER = "fedora-fedmsg-stage"

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -126,7 +126,7 @@ def setDefaultEnvVars(Map envMap=null){
     // We also set dataGrepperUrl which is needed for message tracking
     // and the correct jms-messaging message provider
 
-    if (env.ghprbActualCommit != null && (env.ghprbActualCommit != "master" || env.ghprbGhRepository == "CentOS-PaaS-SIG/upstream-fedora-pipeline")) {
+    if (env.ghprbActualCommit != null && (env.ghprbActualCommit != "master" || env.ghprbPullId != "")) {
         env.MAIN_TOPIC = env.MAIN_TOPIC ?: 'org.centos.stage'
         env.dataGrepperUrl = 'https://apps.stg.fedoraproject.org/datagrepper'
         env.MSG_PROVIDER = "fedora-fedmsg-stage"


### PR DESCRIPTION
Here's the problem. When the ci-pipeline located all packages stage trigger runs, it passes actualCommit = master. This causes that stage run to publish on the prod fedmsg push. When real prod builds run, they have actualCommit = master, but ghprbGhRepository set = to "" from what I have seen. So, we need a compound check for when actualCommit is master. The stage run from ci-pipeline sets ghprbGhRepository to the repo name. So, I think this should fix it.