### PR TITLE
fedoraImageTest function will increase qcow2 fs by 10G before testing…

### DIFF
--- a/vars/fedoraImageTest.groovy
+++ b/vars/fedoraImageTest.groovy
@@ -14,6 +14,10 @@ def call(Map parameters = [:]) {
                 imageName = downloadCompose(imageType: imageType)
             }
 
+            stage('resize compose') {
+                resizeCompose(imageName: imageName, increase: '10G')
+            }
+
             stage('test compose') {
                 testCompose(imageName: imageName)
             }


### PR DESCRIPTION
… the image


depends on:
https://github.com/openshift/contra-lib/pull/19
https://github.com/CentOS-PaaS-SIG/ci-pipeline/pull/734