### PR TITLE
set rpms namespace for koji build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,6 +211,7 @@ timestamps {
                                     pipelineUtils.setBuildBranch(env.fed_request_1 ?: env.fed_info_request_1, "fed")
                                     // Use message bus format to determine if scratch build
                                     env.isScratch = env.fed_info_request_0 ? true : false
+                                    env.fed_namespace = 'rpms'
                                 }
 
 


### PR DESCRIPTION
Currently the pipeline sets namespace to null

https://apps.fedoraproject.org/datagrepper/id?id=2018-24d10fed-d666-4659-b68d-57a1e1d1fd9c&is_raw=true&size=extra-large