### PR TITLE
Add support for pagure.io/fedora-ci/messages

### DIFF
--- a/ContainerJenkinsfile
+++ b/ContainerJenkinsfile
@@ -197,7 +197,7 @@ spec:
                                     packagepipelineUtils.setStageEnvVars(currentStage)
 
                                     // Set our message topic, properties, and content
-                                    messageFields = packagepipelineUtils.setMessageFields("container.test.functional.running", artifact)
+                                    messageFields = packagepipelineUtils.setMessageFields("container.test.functional.running", artifact, true)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.container.test.functional.running on fedmsg
                                     //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
@@ -220,7 +220,7 @@ spec:
                                     }
 
                                     // Set our message topic, properties, and content
-                                    messageFields = packagepipelineUtils.setMessageFields("container.test.functional.complete", artifact)
+                                    messageFields = packagepipelineUtils.setMessageFields("container.test.functional.complete", artifact, true)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.container.test.functional.complete on fedmsg
                                     //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
@@ -237,7 +237,7 @@ spec:
                         currentBuild.result = buildResult
 
                         // Send message org.centos.prod.ci.pipeline.allpackages.<stage>.complete on fedmsg if stage failed
-                        messageFields = packagepipelineUtils.setMessageFields(messageStage, artifact)
+                        messageFields = packagepipelineUtils.setMessageFields(messageStage, artifact, true)
                         //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
 
                         // Report the exception
@@ -256,7 +256,7 @@ spec:
 
                         // Set our message topic, properties, and content
                         // TODO
-                        messageFields = packagepipelineUtils.setMessageFields("complete", artifact)
+                        messageFields = packagepipelineUtils.setMessageFields("complete", artifact, true)
 
                         // Send message org.centos.prod.ci.pipeline.allpackages.complete on fedmsg
                         //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)

--- a/ContainerPRTrigger
+++ b/ContainerPRTrigger
@@ -77,7 +77,7 @@ timestamps {
                     if (validMessage && testsExist && commentTrigger) {
                         // Since pipeline is only functional test stage,
                         // send the message for that stage
-                        messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'pr')
+                        messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'pr', true)
                         //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
 
                         stepName = 'schedule build'
@@ -102,7 +102,7 @@ timestamps {
 
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
-                        messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'pr')
+                        messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'pr', true)
                         //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
                         currentBuild.description = "*Build Skipped*"
                     }

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -96,8 +96,12 @@ timestamps {
                 }
 
                 if (targetBranch && testsExist && primaryKoji) {
-                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build')
+                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build', true)
                     pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+
+                    messageFields = packagepipelineUtils.setMessageFields('queued', 'koji-build', false)
+                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -115,7 +119,7 @@ timestamps {
 
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
-                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build')
+                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build', true)
                     pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
                     currentBuild.description = "*Build Skipped*"
                 }

--- a/JenkinsfilePRTrigger
+++ b/JenkinsfilePRTrigger
@@ -81,7 +81,10 @@ timestamps {
                     }
 
                     if (validMessage && testsExist && commentTrigger) {
-                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr')
+                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr', true)
+                        pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+
+                        messageFields = packagepipelineUtils.setMessageFields('queued', 'dist-git-pr', false)
                         pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
 
                         stepName = 'schedule build'
@@ -106,7 +109,7 @@ timestamps {
 
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
-                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr')
+                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr', true)
                         pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
                         currentBuild.description = "*Build Skipped*"
                     }

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -39,8 +39,12 @@ def setDistBranch() {
  * @param artifact ${MAIN_TOPIC}.ci.pipeline.allpackages-${artifact}.<defined-in-README>
  * @return
  */
-def setMessageFields(String messageType, String artifact) {
-    topic = "${MAIN_TOPIC}.ci.pipeline.allpackages-${artifact}.${messageType}"
+def setMessageFields(String messageType, String artifact, Boolean oldFormat) {
+    if (oldFormat) {
+        topic = "${MAIN_TOPIC}.ci.pipeline.allpackages-${artifact}.${messageType}"
+    } else {
+        topic = "${MAIN_TOPIC}.ci.${artifact}.test.${messageType}"
+    }
     print("Topic is " + topic)
 
     // Create a HashMap of default message property keys and values
@@ -67,12 +71,6 @@ def setMessageFields(String messageType, String artifact) {
             topic            : topic,
             username         : env.fed_owner,
     ]
-
-    // Add image type to appropriate message types
-    if (messageType in ['image.queued', 'image.running', 'image.complete', 'image.test.smoke.queued', 'image.test.smoke.running', 'image.test.smoke.complete'
-    ]) {
-        messageProperties.type = messageType == 'image.running' ? "''" : 'qcow2'
-    }
 
     // Create a string to hold the data from the messageProperties hash map
     String messagePropertiesString = ''

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -26,8 +26,8 @@ class packagepipelineUtils implements Serializable {
      * @param artifact ${MAIN_TOPIC}.ci.pipeline.allpackages-${artifact}.<defined-in-README>
      * @return
      */
-    def setMessageFields(String messageType, String artifact) {
-        packagePipelineUtils.setMessageFields(messageType, artifact)
+    def setMessageFields(String messageType, String artifact, Boolean oldFormat) {
+        packagePipelineUtils.setMessageFields(messageType, artifact, oldFormat)
     }
 
     /**


### PR DESCRIPTION
This patch adds support for the new fedora CI message format.

Also keeps the required topics around, so the switch to the new format
is less painful.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>