### PR TITLE
Remove ci-pipeline functions from this repo

### DIFF
--- a/ContainerBuildTrigger
+++ b/ContainerBuildTrigger
@@ -3,6 +3,7 @@
 
 timestamps {
     def libraries = ['ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
                      'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
 
     libraries.each { name, repo ->
@@ -88,14 +89,13 @@ timestamps {
                         }
                         if (targetBranch) {
                             pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
+                            testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
                             // Ensure message is from primary koji instance
                             primaryKoji = fed_instance == "primary"
                             pipelineUtils.setBuildDisplayAndDescription()
                         } else {
                             currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - Branch: ${env.branch} - Skipped"
                         }
-                        pipelineUtils.initializeAuditFile(msgAuditFile)
 
                     }
 
@@ -105,7 +105,7 @@ timestamps {
                     // Since pipeline is only functional test stage,
                     // send the message for that stage
                     messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'build')
-                    //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -125,7 +125,7 @@ timestamps {
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
                     messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'build')
-                    //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     currentBuild.description = "*Build Skipped*"
                 }
 

--- a/ContainerJenkinsfile
+++ b/ContainerJenkinsfile
@@ -26,6 +26,7 @@ timestamps {
     def podName = 'fedcontainer-' + executionID
 
     def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
                      'ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git']]
 
     libraries.each { name, repo ->
@@ -179,9 +180,7 @@ spec:
                                 packagepipelineUtils.setDefaultEnvVars()
 
                                 // Gather some info about the node we are running on for diagnostics
-                                pipelineUtils.verifyPod(OPENSHIFT_NAMESPACE, env.NODE_NAME)
-                                // create audit message file
-                                pipelineUtils.initializeAuditFile(msgAuditFile)
+                                packagepipelineUtils.verifyPod(OPENSHIFT_NAMESPACE, env.NODE_NAME)
 
                             }
                         }
@@ -189,8 +188,8 @@ spec:
                         currentStage = "container-tests"
                         stage(currentStage) {
                             // Only run this stage if tests exist
-                            if (!pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')) {
-                                pipelineUtils.skip(currentStage)
+                            if (!packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')) {
+                                packagepipelineUtils.skip(currentStage)
                             } else {
                                 packagepipelineUtils.handlePipelineStep(stepName: currentStage, debug: true) {
                                     // Set stage specific vars
@@ -200,7 +199,7 @@ spec:
                                     messageFields = packagepipelineUtils.setMessageFields("container.test.functional.running", artifact)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.container.test.functional.running on fedmsg
-                                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                                     // Prepare to send stage.complete message on failure
                                     env.messageStage = 'container.test.functional.complete'
@@ -209,7 +208,7 @@ spec:
                                     try {
                                         pipelineUtils.executeInContainer(currentStage, "str-container-test", "/home/container-test.sh")
                                     } catch(e) {
-                                        if (pipelineUtils.fileExists("${WORKSPACE}/${currentStage}/logs/test.log")) {
+                                        if (fileExists("${WORKSPACE}/${currentStage}/logs/test.log")) {
                                             buildResult = 'UNSTABLE'
                                             // set currentBuild.result to update the message status
                                             currentBuild.result = buildResult
@@ -240,7 +239,7 @@ spec:
                                     messageFields = packagepipelineUtils.setMessageFields("container.test.functional.complete", artifact)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.container.test.functional.complete on fedmsg
-                                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                                 }
                             }
@@ -255,7 +254,7 @@ spec:
 
                         // Send message org.centos.prod.ci.pipeline.allpackages.<stage>.complete on fedmsg if stage failed
                         messageFields = packagepipelineUtils.setMessageFields(messageStage, artifact)
-                        pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                         // Report the exception
                         echo "Error: Exception from " + currentStage + ":"
@@ -266,7 +265,7 @@ spec:
 
                     } finally {
                         currentBuild.result = buildResult
-                        pipelineUtils.getContainerLogsFromPod(OPENSHIFT_NAMESPACE, env.NODE_NAME)
+                        packagepipelineUtils.getContainerLogsFromPod(OPENSHIFT_NAMESPACE, env.NODE_NAME)
 
                         // Archive our artifacts
                         step([$class: 'ArtifactArchiver', allowEmptyArchive: true, artifacts: '**/logs/**,*.txt,*.groovy,**/job.*,**/*.groovy,**/inventory.*', excludes: '**/*.example', fingerprint: true])
@@ -276,7 +275,7 @@ spec:
                         messageFields = packagepipelineUtils.setMessageFields("complete", artifact)
 
                         // Send message org.centos.prod.ci.pipeline.allpackages.complete on fedmsg
-                        pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                     }
                 }

--- a/ContainerPRCommentTrigger
+++ b/ContainerPRCommentTrigger
@@ -2,8 +2,8 @@
 
 timestamps {
     def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
-                     'ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
-                     'fedora-upstream-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
+                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
 
     libraries.each { name, repo ->
         library identifier: "${name}@${repo[0]}",
@@ -73,15 +73,14 @@ timestamps {
                             print CI_MESSAGE
 
                             packagepipelineUtils.setDefaultEnvVars()
-                            pipelineUtils.injectPRVars("fed", env.CI_MESSAGE)
-                            pipelineUtils.updateBuildDisplayAndDescription()
-                            validMessage = packagepipelineUtils.checkBranch()
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
+                            parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
+                            validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'container', (parsedMsg['pullrequest'].has('id') ? parsedMsg['pullrequest']['id'] : null), 'container')
                             // Function only returns false if comments exist,
                             // but the latest was uninteresting
-                            commentTrigger = pipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
-                            // create audit message file
-                            pipelineUtils.initializeAuditFile(msgAuditFile)
+                            commentTrigger = packagepipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
                         }
                     }
 
@@ -89,7 +88,7 @@ timestamps {
                         // Since pipeline is only functional test stage,
                         // send the message for that stage
                         messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'pr')
-                        //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                         stepName = 'schedule build'
                         stage(stepName) {
@@ -97,7 +96,6 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-
                                         build job: "fedcontainer-${env.branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE)],
                                                 wait: false
@@ -114,7 +112,7 @@ timestamps {
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
                         messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'pr')
-                        //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                         currentBuild.description = "*Build Skipped*"
                     }
 

--- a/ContainerPRNewTrigger
+++ b/ContainerPRNewTrigger
@@ -3,7 +3,7 @@
 timestamps {
     def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
                      'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
-                     'fedora-upstream-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
+                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
 
     libraries.each { name, repo ->
         library identifier: "${name}@${repo[0]}",

--- a/ContainerPRNewTrigger
+++ b/ContainerPRNewTrigger
@@ -2,7 +2,7 @@
 
 timestamps {
     def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
-                     'ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
                      'fedora-upstream-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
 
     libraries.each { name, repo ->
@@ -73,23 +73,19 @@ timestamps {
                             print CI_MESSAGE
 
                             packagepipelineUtils.setDefaultEnvVars()
-                            pipelineUtils.injectPRVars("fed", env.CI_MESSAGE)
-                            pipelineUtils.updateBuildDisplayAndDescription()
-                            validMessage = packagepipelineUtils.checkBranch()
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
-                            // Function only returns false if comments exist,
-                            // but the latest was uninteresting
-                            commentTrigger = pipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
-                            // create audit message file
-                            pipelineUtils.initializeAuditFile(msgAuditFile)
+                            parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
+                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                            validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'container', (parsedMsg['pullrequest'].has('id') ? parsedMsg['pullrequest']['id'] : null), 'container')
                         }
                     }
 
-                    if (validMessage && testsExist && commentTrigger) {
+                    if (validMessage && testsExist) {
                         // Since pipeline is only functional test stage,
                         // send the message for that stage
                         messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'pr')
-                        //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                         stepName = 'schedule build'
                         stage(stepName) {
@@ -97,7 +93,6 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-
                                         build job: "fedcontainer-${env.branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE)],
                                                 wait: false
@@ -114,7 +109,7 @@ timestamps {
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
                         messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'pr')
-                        //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                         currentBuild.description = "*Build Skipped*"
                     }
 

--- a/ContainerTaskTrigger
+++ b/ContainerTaskTrigger
@@ -3,6 +3,7 @@
 
 timestamps {
     def libraries = ['ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
                      'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
 
     libraries.each { name, repo ->
@@ -88,14 +89,13 @@ timestamps {
                         }
                         if (targetBranch) {
                             pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
+                            testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'container', (env.fed_id ?: null), 'container')
                             // Ensure message is from primary koji instance
                             primaryKoji = fed_instance == "primary"
                             pipelineUtils.setBuildDisplayAndDescription()
                         } else {
                             currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - Branch: ${env.branch} - Skipped"
                         }
-                        pipelineUtils.initializeAuditFile(msgAuditFile)
 
                     }
 
@@ -105,7 +105,7 @@ timestamps {
                     // Since pipeline is only functional test stage,
                     // send the message for that stage
                     messageFields = packagepipelineUtils.setMessageFields('container.test.functional.queued', 'build')
-                    //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -125,7 +125,7 @@ timestamps {
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
                     messageFields = packagepipelineUtils.setMessageFields('container.ignored', 'build')
-                    //pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    //sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     currentBuild.description = "*Build Skipped*"
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,7 +227,9 @@ timestamps {
                                     // Scratch build messages store things in info
                                     packagepipelineUtils.setScratchVars(parsedMsg)
                                     env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
-                                    env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
+                                    branches = packagepipelineUtils.setBuildBranch(env.request_1)
+                                    env.branch = branches[0]
+                                    env.fed_branch = branches[1]
                                     env.fed_namespace = 'rpms'
                                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,7 +243,7 @@ timestamps {
 
                                 // Send message org.centos.prod.ci.<artifact>.test.running on fedmsg
                                 messageFields = packagepipelineUtils.setTestMessageFields("running", artifact)
-                                pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                                pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['content'], '', msgAuditFile, fedmsgRetryCount)
 
                             }
                         }
@@ -432,7 +432,7 @@ timestamps {
 
                                     // Send message org.centos.prod.ci.<artifact>.test.complete on fedmsg
                                     messageFields = packagepipelineUtils.setTestMessageFields("complete", artifact)
-                                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['content'], '', msgAuditFile, fedmsgRetryCount)
 
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,8 @@ timestamps {
                                 parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
 
                                 if (!env.PROVIDED_KOJI_TASKID?.trim()) {
-                                    env.artifact = 'pr'
+                                    env.artifact = 'dist-git-pr'
+                                    env.artifactOld = 'pr'
 
                                     // Set required env variables from msg
                                     env.fed_namespace = parsedMsg['pullrequest']['project']['namespace']
@@ -221,7 +222,8 @@ timestamps {
                                     currentBuild.displayName = buildName
                                     currentBuild.description = buildName
                                 } else {
-                                    env.artifact = 'build'
+                                    env.artifact = 'koij-build'
+                                    env.artifactOld = 'build'
                                     // Scratch build messages store things in info
                                     packagepipelineUtils.setScratchVars(parsedMsg)
                                     env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
@@ -239,7 +241,7 @@ timestamps {
                                 packagepipelineUtils.verifyPod(OPENSHIFT_NAMESPACE, env.NODE_NAME)
 
                                 // Send message org.centos.prod.ci.<artifact>.test.running on fedmsg
-                                messageFields = packagepipelineUtils.setTestMessageFields("running", artifact)
+                                messageFields = packagepipelineUtils.setTestMessageFields("running", artifact, parsedMsg)
                                 packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                             }
                         }
@@ -253,7 +255,7 @@ timestamps {
                                 stageVars = packagepipelineUtils.setStageEnvVars(currentStage)
 
                                 // Return a map (messageFields) of our message topic, properties, and content
-                                messageFields = packagepipelineUtils.setMessageFields("package.running", artifact, parsedMsg)
+                                messageFields = packagepipelineUtils.setMessageFields("package.running", artifactOld, parsedMsg)
 
                                 // Send message org.centos.prod.ci.pipeline.allpackages.package.running on fedmsg
                                 packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -312,13 +314,13 @@ timestamps {
                             }
 
                             // Set our message topic, properties, and content
-                            messageFields = packagepipelineUtils.setMessageFields("package.complete", artifact, parsedMsg)
+                            messageFields = packagepipelineUtils.setMessageFields("package.complete", artifactOld, parsedMsg)
 
                             // Send message org.centos.prod.ci.pipeline.allpackages.package.complete on fedmsg
                             packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                             // Set our message topic, properties, and content
-                            messageFields = packagepipelineUtils.setMessageFields("image.queued", artifact, parsedMsg)
+                            messageFields = packagepipelineUtils.setMessageFields("image.queued", artifactOld, parsedMsg)
 
                             // Send message org.centos.prod.ci.pipeline.allpackages.image.queued on fedmsg
                             packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -330,7 +332,7 @@ timestamps {
                             packagepipelineUtils.handlePipelineStep(stepName: env.currentStage, debug: true) {
 
                                 // Set our message topic, properties, and content
-                                messageFields = packagepipelineUtils.setMessageFields("image.running", artifact, parsedMsg)
+                                messageFields = packagepipelineUtils.setMessageFields("image.running", artifactOld, parsedMsg)
 
                                 // Send message org.centos.prod.ci.pipeline.allpackages.image.running on fedmsg
                                 packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -348,7 +350,7 @@ timestamps {
                                                    stageName: currentStage)
 
                                 // Set our message topic, properties, and content
-                                messageFields = packagepipelineUtils.setMessageFields("image.complete", artifact, parsedMsg)
+                                messageFields = packagepipelineUtils.setMessageFields("image.complete", artifactOld, parsedMsg)
 
                                 // Send message org.centos.prod.ci.pipeline.allpackages.image.complete on fedmsg
                                 packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -386,7 +388,7 @@ timestamps {
                             } else {
                                 packagepipelineUtils.handlePipelineStep(stepName: env.currentStage, debug: true) {
                                     // Set our message topic, properties, and content
-                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.queued", artifact, parsedMsg)
+                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.queued", artifactOld, parsedMsg)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.package.test.functional.queued on fedmsg
                                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -395,7 +397,7 @@ timestamps {
                                     stageVars = packagepipelineUtils.setStageEnvVars(currentStage)
 
                                     // Set our message topic, properties, and content
-                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.running", artifact, parsedMsg)
+                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.running", artifactOld, parsedMsg)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.package.test.functional.running on fedmsg
                                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
@@ -441,13 +443,13 @@ timestamps {
                                     }
 
                                     // Set our message topic, properties, and content
-                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.complete", artifact, parsedMsg)
+                                    messageFields = packagepipelineUtils.setMessageFields("package.test.functional.complete", artifactOld, parsedMsg)
 
                                     // Send message org.centos.prod.ci.pipeline.allpackages.package.test.functional.complete on fedmsg
                                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                                     // Send message org.centos.prod.ci.<artifact>.test.complete on fedmsg
-                                    messageFields = packagepipelineUtils.setTestMessageFields("complete", artifact)
+                                    messageFields = packagepipelineUtils.setTestMessageFields("complete", artifact, parsedMsg)
                                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
 
@@ -467,7 +469,7 @@ timestamps {
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Send message org.centos.prod.ci.<artifact>.test.error on fedmsg
-                        messageFields = packagepipelineUtils.setTestMessageFields("error", artifact)
+                        messageFields = packagepipelineUtils.setTestMessageFields("error", artifact, parsedMsg)
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Report the exception
@@ -486,7 +488,7 @@ timestamps {
                         }
 
                         // Set our message topic, properties, and content
-                        messageFields = packagepipelineUtils.setMessageFields("complete", artifact, parsedMsg)
+                        messageFields = packagepipelineUtils.setMessageFields("complete", artifactOld, parsedMsg)
 
                         // Send message org.centos.prod.ci.pipeline.allpackages.complete on fedmsg
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -429,7 +429,7 @@ timestamps {
                                         }
                                     }
 
-                                    if (pipelineUtils.fileExists("${WORKSPACE}/${env.currentStage}/logs/results.yml")) {
+                                    if (fileExists("${WORKSPACE}/${env.currentStage}/logs/results.yml")) {
                                         def test_results = readYaml file: "${WORKSPACE}/${env.currentStage}/logs/results.yml"
                                         def test_failed = false
                                         test_results['results'].each { result ->

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,6 +241,10 @@ timestamps {
                                 messageFields = packagepipelineUtils.setTestMessageFields("running", artifact)
                                 pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
+                                // Send message org.centos.prod.ci.<artifact>.test.running on fedmsg
+                                messageFields = packagepipelineUtils.setTestMessageFields("running", artifact)
+                                pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+
                             }
                         }
 
@@ -425,6 +429,10 @@ timestamps {
                                     // Send message org.centos.prod.ci.<artifact>.test.complete on fedmsg
                                     messageFields = packagepipelineUtils.setTestMessageFields("complete", artifact)
                                     pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+
+                                    // Send message org.centos.prod.ci.<artifact>.test.complete on fedmsg
+                                    messageFields = packagepipelineUtils.setTestMessageFields("complete", artifact)
+                                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
 
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,6 +283,8 @@ timestamps {
                                 } else {
                                     // For tests namespace there is no package to build
                                     if (env.fed_namespace != "tests" ) {
+                                        // koji_build_pr relies on fed_uid var
+                                        stageVars['fed_uid'] = parsedMsg['pullrequest']['uid']
                                         // Build rpms
                                         executeInContainer(containerName: "rpmbuild",
                                                            containerScript: "/tmp/koji_build_pr.sh",
@@ -427,7 +429,7 @@ timestamps {
                                         }
                                     }
 
-                                    if (pipelineUtils.fileExists("${WORKSPACE}/${currentStage}/logs/results.yml")) {
+                                    if (fileExists("${WORKSPACE}/${currentStage}/logs/results.yml")) {
                                         def test_results = readYaml file: "${WORKSPACE}/${currentStage}/logs/results.yml"
                                         def test_failed = false
                                         test_results['results'].each { result ->

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,15 +223,7 @@ timestamps {
                                 } else {
                                     env.artifact = 'build'
                                     // Scratch build messages store things in info
-                                    if (parsedMsg.has('info')) {
-                                        env.isScratch = true
-                                        env.request_0 = parsedMsg['info']['request'][0]
-                                        env.request_1 = parsedMsg['info']['request'][1]
-                                    } else {
-                                        env.isScratch = false
-                                        env.request_0 = parsedMsg['request'][0]
-                                        env.request_1 = parsedMsg['request'][1]
-                                    }
+                                    packagepipelineUtils.setScratchVars(parsedMsg)
                                     env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
                                     env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
                                     env.fed_namespace = 'rpms'

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -63,7 +63,9 @@ timestamps {
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
-                            env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
+                            branches = packagepipelineUtils.setBuildBranch(env.request_1)
+                            env.branch = branches[0]
+                            env.fed_branch = branches[1]
                             targetBranch = packagepipelineUtils.checkBranch(env.fed_branch)
                             def tagMatcher = env.fed_request_1 =~ /f([0-9]+)-candidate/
                             if (!tagMatcher && env.fed_request_1 != 'rawhide') {

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -64,7 +64,7 @@ timestamps {
                         targetBranch = false
                         if (env.fed_request_1) {
                             env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
-                            targetBranch = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            targetBranch = packagepipelineUtils.checkBranch(env.fed_branch)
                             def tagMatcher = env.fed_request_1 =~ /f([0-9]+)-candidate/
                             if (!tagMatcher && env.fed_request_1 != 'rawhide') {
                                 print("Don't trigger test for build with Build Target tag: ${env.fed_request_1}")
@@ -72,20 +72,20 @@ timestamps {
                             }
                         }
 
-                        if (env.fed_owner == "mbs/mbs.fedoraproject.org" || env.fed_owner == "koschei") {
+                        if (parsedMsg['owner'] == "mbs/mbs.fedoraproject.org" || parsedMsg['owner'] == "koschei") {
                             print("Not triggering for modules or koschei builds")
                             targetBranch = false
                         }
 
                         // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run
-                        if (parsedMsg['owner'] == "bpeck/jenkins-continuous-infra.apps.ci.centos.org" || parsedMsg['owner'] == "koschei") {
->>>>>>> Removing ci-pipeline functions
+                        if (parsedMsg['owner'] == "bpeck/jenkins-continuous-infra.apps.ci.centos.org") {
                             print("This build is for a scratch build from the PR pipeline. Not triggering.")
                             targetBranch = false
                         }
 
                         if (targetBranch) {
                             env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
+                            env.fed_namespace = 'rpms' // used in setMessageFields
                             testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
                             // Ensure message is from primary koji instance
                             primaryKoji = parsedMsg['instance'] == "primary"
@@ -102,7 +102,7 @@ timestamps {
                     messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build', parsedMsg)
                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     // Send message org.centos.prod.ci.koji-build.test.queued on fedmsg
-                    messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build")
+                    messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build", parsedMsg)
                     packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                     stepName = 'schedule build'

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -59,15 +59,7 @@ timestamps {
                         print "CI_MESSAGE"
                         print CI_MESSAGE
                         parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
-                        if (parsedMsg.has('info')) {
-                            env.isScratch = true
-                            env.request_0 = parsedMsg['info']['request'][0]
-                            env.request_1 = parsedMsg['info']['request'][1]
-                        } else {
-                            env.isScratch = false
-                            env.request_0 = parsedMsg['request'][0]
-                            env.request_1 = parsedMsg['request'][1]
-                        }
+                        packagepipelineUtils.setScratchVars(parsedMsg)
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -2,8 +2,7 @@
 
 
 timestamps {
-    def libraries = ['ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
-                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
+    def libraries = ['upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
                      'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git']]
 
     libraries.each { name, repo ->
@@ -59,20 +58,21 @@ timestamps {
 
                         print "CI_MESSAGE"
                         print CI_MESSAGE
-                        pipelineUtils.flattenJSON('fed', env.CI_MESSAGE)
-                        // Get request vars from scratch messages
-                        env.fed_request_0 = env.fed_request_0 ?: env.fed_info_request_0
-                        env.fed_request_1 = env.fed_request_1 ?: env.fed_info_request_1
-                        // Determine if scratch build
-                        env.isScratch = false
-                        if (env.fed_info_request_0) {
+                        parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                        if (parsedMsg.has('info')) {
                             env.isScratch = true
+                            env.request_0 = parsedMsg['info']['request'][0]
+                            env.request_1 = parsedMsg['info']['request'][1]
+                        } else {
+                            env.isScratch = false
+                            env.request_0 = parsedMsg['request'][0]
+                            env.request_1 = parsedMsg['request'][1]
                         }
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
-                            pipelineUtils.setBuildBranch(env.fed_request_1, "fed")
-                            targetBranch = packagepipelineUtils.checkBranch()
+                            env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
+                            targetBranch = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
                             def tagMatcher = env.fed_request_1 =~ /f([0-9]+)-candidate/
                             if (!tagMatcher && env.fed_request_1 != 'rawhide') {
                                 print("Don't trigger test for build with Build Target tag: ${env.fed_request_1}")
@@ -86,17 +86,18 @@ timestamps {
                         }
 
                         // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run
-                        if (env.fed_owner == "bpeck/jenkins-continuous-infra.apps.ci.centos.org") {
+                        if (parsedMsg['owner'] == "bpeck/jenkins-continuous-infra.apps.ci.centos.org" || parsedMsg['owner'] == "koschei") {
+>>>>>>> Removing ci-pipeline functions
                             print("This build is for a scratch build from the PR pipeline. Not triggering.")
                             targetBranch = false
                         }
 
                         if (targetBranch) {
-                            pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
+                            env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
+                            testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
                             // Ensure message is from primary koji instance
-                            primaryKoji = fed_instance == "primary"
-                            pipelineUtils.setBuildDisplayAndDescription()
+                            primaryKoji = parsedMsg['instance'] == "primary"
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${env.fed_branch} - Package: ${env.fed_repo}"
                         } else {
                             currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - Branch: ${env.branch} - Skipped"
                         }
@@ -106,11 +107,12 @@ timestamps {
                 }
 
                 if (targetBranch && testsExist && primaryKoji) {
-                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build')
-                    pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build', parsedMsg)
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     // Send message org.centos.prod.ci.koji-build.test.queued on fedmsg
                     messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build")
-                    pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -129,8 +131,8 @@ timestamps {
 
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
-                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build')
-                    pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build', parsedMsg)
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     currentBuild.description = "*Build Skipped*"
                 }
 

--- a/JenkinsfilePRCommentTrigger
+++ b/JenkinsfilePRCommentTrigger
@@ -5,8 +5,7 @@ timestamps {
     // Might just keep this for legacy reasons for now
     def CANNED_CI_MESSAGE = '{"commit":{"username":"zdohnal","stats":{"files":{"README.patches":{"deletions":0,"additions":30,"lines":30},"sources":{"deletions":1,"additions":1,"lines":2},"vim.spec":{"deletions":7,"additions":19,"lines":26},".gitignore":{"deletions":0,"additions":1,"lines":1},"vim-8.0-rhbz1365258.patch":{"deletions":0,"additions":12,"lines":12}},"total":{"deletions":8,"files":5,"additions":63,"lines":71}},"name":"Zdenek Dohnal","rev":"3ff427e02625f810a2cedb754342be44d6161b39","namespace":"rpms","agent":"zdohnal","summary":"Merge branch f25 into f26","repo":"vim","branch":"f26","seen":false,"path":"/srv/git/repositories/rpms/vim.git","message":"Merge branch \'f25\' into f26\n","email":"zdohnal@redhat.com"},"topic":"org.fedoraproject.prod.git.receive"}'
 
-    def libraries = ['ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
-                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
+    def libraries = ['upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
                      'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git']]
 
     libraries.each { name, repo ->

--- a/JenkinsfilePRCommentTrigger
+++ b/JenkinsfilePRCommentTrigger
@@ -74,10 +74,7 @@ timestamps {
                             parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
                             currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
                             validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
-                            // Set env vars required for setMessageFields
-                            env.fed_namespace = parsedMsg['pullrequest']['project']['namespace']
-                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
-                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], env.fed_namespace)
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], parsedMsg['pullrequest']['project']['namespace'])
                             // Function only returns false if comments exist,
                             // but the latest was uninteresting
                             commentTrigger = packagepipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
@@ -89,12 +86,8 @@ timestamps {
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
-                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
+                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr", parsedMsg)
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
-
-                        // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
-                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
-                        sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                         stepName = 'schedule build'
                         stage(stepName) {
@@ -102,7 +95,8 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-                                        build job: "fedora-${env.branch}-pr-pipeline",
+                                        branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                                        build job: "fedora-${branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE),
                                                              string(name: 'pipelineId', value: UUID.randomUUID().toString())],
                                                 wait: false

--- a/JenkinsfilePRCommentTrigger
+++ b/JenkinsfilePRCommentTrigger
@@ -71,27 +71,30 @@ timestamps {
                             print CI_MESSAGE
 
                             packagepipelineUtils.setDefaultEnvVars()
-                            pipelineUtils.injectPRVars("fed", env.CI_MESSAGE)
-                            pipelineUtils.updateBuildDisplayAndDescription()
-                            validMessage = packagepipelineUtils.checkBranch()
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic', env.fed_id, env.fed_namespace)
+                            parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
+                            validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            // Set env vars required for setMessageFields
+                            env.fed_namespace = parsedMsg['pullrequest']['project']['namespace']
+                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], env.fed_namespace)
                             // Function only returns false if comments exist,
                             // but the latest was uninteresting
-                            commentTrigger = pipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
+                            commentTrigger = packagepipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
                         }
                     }
 
                     if (validMessage && testsExist && commentTrigger) {
-                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr')
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr', parsedMsg)
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
                         messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
                         messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
-                        pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                        sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
 
                         stepName = 'schedule build'
                         stage(stepName) {
@@ -99,7 +102,6 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-
                                         build job: "fedora-${env.branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE),
                                                              string(name: 'pipelineId', value: UUID.randomUUID().toString())],
@@ -116,8 +118,8 @@ timestamps {
 
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
-                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr')
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr', parsedMsg)
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                         currentBuild.description = "*Build Skipped*"
                     }
 

--- a/JenkinsfilePRCommentTrigger
+++ b/JenkinsfilePRCommentTrigger
@@ -89,6 +89,10 @@ timestamps {
                         messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
                         pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
+                        // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
+                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
+                        pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+
                         stepName = 'schedule build'
                         stage(stepName) {
 

--- a/JenkinsfilePRNewTrigger
+++ b/JenkinsfilePRNewTrigger
@@ -73,10 +73,7 @@ timestamps {
                             parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
                             currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
                             validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
-                            // Set env vars required for setMessageFields
-                            env.fed_namespace = parsedMsg['pullrequest']['project']['namespace']
-                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
-                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], env.fed_namespace)
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], parsedMsg['pullrequest']['project']['namespace'])
                         }
                     }
 
@@ -85,7 +82,7 @@ timestamps {
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
-                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
+                        messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr", parsedMsg)
                         packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         stepName = 'schedule build'
@@ -94,7 +91,8 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-                                        build job: "fedora-${env.branch}-pr-pipeline",
+                                        branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                                        build job: "fedora-${branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE),
                                                              string(name: 'pipelineId', value: UUID.randomUUID().toString())],
                                                 wait: false

--- a/JenkinsfilePRNewTrigger
+++ b/JenkinsfilePRNewTrigger
@@ -6,9 +6,8 @@ timestamps {
     def CANNED_CI_MESSAGE = '{"commit":{"username":"zdohnal","stats":{"files":{"README.patches":{"deletions":0,"additions":30,"lines":30},"sources":{"deletions":1,"additions":1,"lines":2},"vim.spec":{"deletions":7,"additions":19,"lines":26},".gitignore":{"deletions":0,"additions":1,"lines":1},"vim-8.0-rhbz1365258.patch":{"deletions":0,"additions":12,"lines":12}},"total":{"deletions":8,"files":5,"additions":63,"lines":71}},"name":"Zdenek Dohnal","rev":"3ff427e02625f810a2cedb754342be44d6161b39","namespace":"rpms","agent":"zdohnal","summary":"Merge branch f25 into f26","repo":"vim","branch":"f26","seen":false,"path":"/srv/git/repositories/rpms/vim.git","message":"Merge branch \'f25\' into f26\n","email":"zdohnal@redhat.com"},"topic":"org.fedoraproject.prod.git.receive"}'
 
     def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
-                     'ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
-                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
-                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
+                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git']]
 
     libraries.each { name, repo ->
         library identifier: "${name}@${repo[0]}",
@@ -23,19 +22,19 @@ timestamps {
                     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
                     disableConcurrentBuilds(),
                     pipelineTriggers(
-                            [[$class: 'CIBuildTrigger',
-                              noSquash: true,
-                              providerData: [
-                                  $class: 'FedMsgSubscriberProviderData',
-                                  name: 'fedora-fedmsg',
-                                  overrides: [
-                                      topic: 'org.fedoraproject.prod.pagure.pull-request.new'
-                                  ],
-                                  checks: [
-                                      [field: '$.pullrequest.project.namespace', expectedValue: 'rpms|tests']
-                                  ]
+                        [[$class: 'CIBuildTrigger',
+                          noSquash: true,
+                          providerData: [
+                              $class: 'FedMsgSubscriberProviderData',
+                              name: 'fedora-fedmsg',
+                              overrides: [
+                                  topic: 'org.fedoraproject.prod.pagure.pull-request.new'
+                              ],
+                              checks: [
+                                  [field: '$.pullrequest.project.namespace', expectedValue: 'rpms|tests']
                               ]
-                            ]]
+                          ]
+                        ]]
                     ),
 
                     parameters(
@@ -71,22 +70,23 @@ timestamps {
                             print CI_MESSAGE
 
                             packagepipelineUtils.setDefaultEnvVars()
-                            pipelineUtils.injectPRVars("fed", env.CI_MESSAGE)
-                            pipelineUtils.updateBuildDisplayAndDescription()
-                            validMessage = packagepipelineUtils.checkBranch()
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic', env.fed_id, env.fed_namespace)
-                            // Function only returns false if comments exist,
-                            // but the latest was uninteresting
-                            commentTrigger = pipelineUtils.checkUpdatedPR(env.CI_MESSAGE, '[citest]')
+                            parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${parsedMsg['pullrequest']['branch']} - Package: ${parsedMsg['pullrequest']['project']['name']}"
+                            validMessage = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            // Set env vars required for setMessageFields
+                            env.fed_namespace = parsedMsg['pullrequest']['project']['namespace']
+                            env.branch = (parsedMsg['pullrequest']['branch'] == 'master') ? 'rawhide' : parsedMsg['pullrequest']['branch']
+                            testsExist = packagepipelineUtils.checkTests(parsedMsg['pullrequest']['project']['name'], parsedMsg['pullrequest']['branch'], 'classic', parsedMsg['pullrequest']['id'], env.fed_namespace)
                         }
                     }
 
-                    if (validMessage && testsExist && commentTrigger) {
-                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr')
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                    if (validMessage && testsExist) {
+                        messageFields = packagepipelineUtils.setMessageFields('package.queued', 'pr', parsedMsg)
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+
                         // Send message org.centos.prod.ci.dist-git-pr.test.queued on fedmsg
                         messageFields = packagepipelineUtils.setTestMessageFields("queued", "dist-git-pr")
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
 
                         stepName = 'schedule build'
                         stage(stepName) {
@@ -94,7 +94,6 @@ timestamps {
                             try {
                                 retry(TRIGGER_RETRY_COUNT) {
                                     packagepipelineUtils.handlePipelineStep(stepName: stepName, debug: true) {
-
                                         build job: "fedora-${env.branch}-pr-pipeline",
                                                 parameters: [string(name: 'CI_MESSAGE', value: env.CI_MESSAGE),
                                                              string(name: 'pipelineId', value: UUID.randomUUID().toString())],
@@ -111,8 +110,8 @@ timestamps {
 
                     } else {
                         echo "CI_MESSAGE was invalid. Skipping..."
-                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr')
-                        pipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
+                        messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'pr', parsedMsg)
+                        packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                         currentBuild.description = "*Build Skipped*"
                     }
 

--- a/JenkinsfileStageTrigger
+++ b/JenkinsfileStageTrigger
@@ -80,7 +80,7 @@ pipeline {
                 node('master') {
                     script {
                         echo "PR number is: ${env.ghprbPullId}"
-                        env.changeLogStr = pipelineUtils.getChangeLogFromCurrentBuild()
+                        env.changeLogStr = packagepipelineUtils.getChangeLogFromCurrentBuild()
                         echo env.changeLogStr
                     }
                     writeFile file: 'changelog.txt', text: env.changeLogStr
@@ -128,7 +128,7 @@ pipeline {
                     prMsg = "(PR #${env.ghprbPullId} ${env.ghprbPullAuthorLogin})"
                 }
                 def message = "${JOB_NAME} ${prMsg} build #${BUILD_NUMBER}: ${currentBuild.currentResult}: ${BUILD_URL}"
-                pipelineUtils.sendIRCNotification("${IRC_NICK}-${UUID.randomUUID()}", IRC_CHANNEL, message)
+                packagepipelineUtils.sendIRCNotification("${IRC_NICK}-${UUID.randomUUID()}", IRC_CHANNEL, message)
             }
         }
         success {

--- a/JenkinsfileStageTrigger
+++ b/JenkinsfileStageTrigger
@@ -27,12 +27,22 @@ CANNED_CI_MESSAGES['f27'] = '{"pullrequest":{"status":"Merged","last_updated":"1
 CANNED_CI_MESSAGES['rawhide'] = '{"pullrequest":{"last_updated":"1557907130","uid":"b08cc62005f643a39fa66f7c4891dac4","initial_comment":null,"commit_stop":"1c474a3f55b792c378c6f1a0a8075335d87eff03","remote_git":null,"closed_at":null,"id":6,"title":"just dummy PR to use the patch on stage Fedora CI pipeline","comments":[],"branch":"master","status":"Open","tags":[],"user":{"fullname":"Bruno Goncalves","name":"bgoncalv"},"date_created":"1557907130","closed_by":null,"branch_from":"dummy-test","assignee":null,"commit_start":"1c474a3f55b792c378c6f1a0a8075335d87eff03","project":{"custom_keys":[],"description":"The ksh rpms","parent":null,"date_modified":"1507637032","access_users":{"admin":["mhlavink"],"commit":["kdudka"],"ticket":[],"owner":["svashisht"]},"namespace":"rpms","priorities":{},"id":7896,"access_groups":{"admin":[],"commit":[],"ticket":[]},"milestones":{},"user":{"fullname":"Siteshwar Vashisht","name":"svashisht"},"date_created":"1501870087","fullname":"rpms/ksh","url_path":"rpms/ksh","close_status":[],"tags":[],"name":"ksh"},"repo_from":{"custom_keys":[],"description":"The ksh rpms","parent":{"custom_keys":[],"description":"The ksh rpms","parent":null,"date_modified":"1507637032","access_users":{"admin":["mhlavink"],"commit":["kdudka"],"ticket":[],"owner":["svashisht"]},"namespace":"rpms","priorities":{},"id":7896,"access_groups":{"admin":[],"commit":[],"ticket":[]},"milestones":{},"user":{"fullname":"Siteshwar Vashisht","name":"svashisht"},"date_created":"1501870087","fullname":"rpms/ksh","url_path":"rpms/ksh","close_status":[],"tags":[],"name":"ksh"},"date_modified":"1557906960","access_users":{"admin":[],"commit":[],"ticket":[],"owner":["bgoncalv"]},"namespace":"rpms","priorities":{},"id":36015,"access_groups":{"admin":[],"commit":[],"ticket":[]},"milestones":{},"user":{"fullname":"Bruno Goncalves","name":"bgoncalv"},"date_created":"1557906960","fullname":"forks/bgoncalv/rpms/ksh","url_path":"fork/bgoncalv/rpms/ksh","close_status":[],"tags":[],"name":"ksh"},"cached_merge_status":"unknown","updated_on":"1557907130","threshold_reached":null},"agent":"bgoncalv"}'
 
 def libraries = ['cico-pipeline'           : ['master', 'https://github.com/CentOS/cico-pipeline-library.git'],
-                 'ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git']]
+                 'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib']]
 
 libraries.each { name, repo ->
     library identifier: "${name}@${repo[0]}",
             retriever: modernSCM([$class: 'GitSCMSource',
                                   remote: repo[1]])
+
+// Check out PR's version of library
+library identifier: "upstream-fedora-pipeline@${env.ghprbActualCommit}",
+        retriever: modernSCM([$class: 'GitSCMSource',
+                              remote: "https://github.com/${env.ghprbGhRepository}",
+                              traits: [[$class: 'jenkins.plugins.git.traits.BranchDiscoveryTrait'],
+                                       [$class: 'RefSpecsSCMSourceTrait',
+                                        templates: [[value: '+refs/heads/*:refs/remotes/@{remote}/*'],
+                                                    [value: '+refs/pull/*:refs/remotes/origin/pr/*']]]]])
+
 properties([
   buildDiscarder(logRotator(artifactNumToKeepStr: '20', numToKeepStr: '20')),
   [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline/'],

--- a/JenkinsfileTaskTrigger
+++ b/JenkinsfileTaskTrigger
@@ -2,9 +2,8 @@
 
 
 timestamps {
-    def libraries = ['ci-pipeline'             : ['master', 'https://github.com/CentOS-PaaS-SIG/ci-pipeline.git'],
-                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git'],
-                     'upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git']]
+    def libraries = ['upstream-fedora-pipeline': ['master', 'https://github.com/CentOS-PaaS-SIG/upstream-fedora-pipeline.git'],
+                     'contra-lib'              : ['master', 'https://github.com/openshift/contra-lib.git']]
 
     libraries.each { name, repo ->
         library identifier: "${name}@${repo[0]}",
@@ -66,44 +65,47 @@ timestamps {
 
                         print "CI_MESSAGE"
                         print CI_MESSAGE
-                        pipelineUtils.flattenJSON('fed', env.CI_MESSAGE)
-                        // Get request vars from scratch messages
-                        env.fed_request_0 = env.fed_request_0 ?: env.fed_info_request_0
-                        env.fed_request_1 = env.fed_request_1 ?: env.fed_info_request_1
-                        // Determine if scratch build
-                        env.isScratch = false
-                        if (env.fed_info_request_0) {
+                        parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
+                        if (parsedMsg.has('info')) {
                             env.isScratch = true
+                            env.request_0 = parsedMsg['info']['request'][0]
+                            env.request_1 = parsedMsg['info']['request'][1]
+                        } else {
+                            env.isScratch = false
+                            env.request_0 = parsedMsg['request'][0]
+                            env.request_1 = parsedMsg['request'][1]
                         }
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
-                            pipelineUtils.setBuildBranch(env.fed_request_1, "fed")
-                            targetBranch = packagepipelineUtils.checkBranch()
+                            env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
+                            targetBranch = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
                         }
                         // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run
-                        if (env.fed_owner == "bpeck/jenkins-continuous-infra.apps.ci.centos.org" || env.fed_owner == "koschei") {
+                        if (parsedMsg['owner'] == "bpeck/jenkins-continuous-infra.apps.ci.centos.org" || parsedMsg['owner'] == "koschei") {
                             print("This build is for a scratch build from the PR pipeline. Not triggering.")
                             targetBranch = false
                         }
                         if (targetBranch) {
-                            pipelineUtils.repoFromRequest(env.fed_request_0, 'fed')
-                            testsExist = pipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
+                            env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
+                            testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
                             // Ensure message is from primary koji instance
-                            primaryKoji = fed_instance == "primary"
-                            pipelineUtils.setBuildDisplayAndDescription()
+                            primaryKoji = parsedMsg['instance'] == "primary"
+                            currentBuild.displayName = "BUILD#: ${env.BUILD_NUMBER} - Branch: ${env.fed_branch} - Package: ${env.fed_repo}"
                         } else {
                             currentBuild.displayName = "Build#: ${env.BUILD_NUMBER} - Branch: ${env.branch} - Skipped"
                         }
-                        pipelineUtils.initializeAuditFile(msgAuditFile)
 
                     }
 
                 }
 
                 if (targetBranch && testsExist && primaryKoji) {
-                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build')
-                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build', parsedMsg)
+                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
+                    // Send message org.centos.prod.ci.koji-build.test.queued on fedmsg
+                    messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build")
+                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -121,8 +123,8 @@ timestamps {
 
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
-                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build')
-                    pipelineUtils.sendMessageWithAudit(messageFields['topic'], messageFields['properties'], messageFields['content'], msgAuditFile, fedmsgRetryCount)
+                    messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build', parsedMsg)
+                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
                     currentBuild.description = "*Build Skipped*"
                 }
 

--- a/JenkinsfileTaskTrigger
+++ b/JenkinsfileTaskTrigger
@@ -71,7 +71,7 @@ timestamps {
                         targetBranch = false
                         if (env.fed_request_1) {
                             env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
-                            targetBranch = packagepipelineUtils.checkBranch(parsedMsg['pullrequest']['branch'])
+                            targetBranch = packagepipelineUtils.checkBranch(env.fed_branch)
                         }
                         // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run
                         if (parsedMsg['owner'] == "bpeck/jenkins-continuous-infra.apps.ci.centos.org" || parsedMsg['owner'] == "koschei") {
@@ -80,6 +80,7 @@ timestamps {
                         }
                         if (targetBranch) {
                             env.fed_repo = packagepipelineUtils.repoFromRequest(env.request_0)
+                            env.fed_namespace = 'rpms' // Used in setMessageFields
                             testsExist = packagepipelineUtils.checkTests(env.fed_repo, env.fed_branch, 'classic')
                             // Ensure message is from primary koji instance
                             primaryKoji = parsedMsg['instance'] == "primary"
@@ -94,10 +95,10 @@ timestamps {
 
                 if (targetBranch && testsExist && primaryKoji) {
                     messageFields = packagepipelineUtils.setMessageFields('package.queued', 'build', parsedMsg)
-                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     // Send message org.centos.prod.ci.koji-build.test.queued on fedmsg
-                    messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build")
-                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
+                    messageFields = packagepipelineUtils.setTestMessageFields("queued", "koji-build", parsedMsg)
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     stepName = 'schedule build'
                     stage(stepName) {
 
@@ -116,7 +117,7 @@ timestamps {
                 } else {
                     echo "CI_MESSAGE was invalid. Skipping..."
                     messageFields = packagepipelineUtils.setMessageFields('package.ignored', 'build', parsedMsg)
-                    sendMessageWithAudit(msgTopic: messageFields['topic'], msgProps: messageFields['properties'], msgContent: messageFields['content'], msgRetryCount: fedmsgRetryCount)
+                    packagepipelineUtils.sendMessage(messageFields['topic'], messageFields['properties'], messageFields['content'])
                     currentBuild.description = "*Build Skipped*"
                 }
 

--- a/JenkinsfileTaskTrigger
+++ b/JenkinsfileTaskTrigger
@@ -66,15 +66,7 @@ timestamps {
                         print "CI_MESSAGE"
                         print CI_MESSAGE
                         parsedMsg = kojiMessage(message: env.CI_MESSAGE, ignoreErrors: true)
-                        if (parsedMsg.has('info')) {
-                            env.isScratch = true
-                            env.request_0 = parsedMsg['info']['request'][0]
-                            env.request_1 = parsedMsg['info']['request'][1]
-                        } else {
-                            env.isScratch = false
-                            env.request_0 = parsedMsg['request'][0]
-                            env.request_1 = parsedMsg['request'][1]
-                        }
+                        packagepipelineUtils.setScratchVars(parsedMsg)
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {

--- a/JenkinsfileTaskTrigger
+++ b/JenkinsfileTaskTrigger
@@ -70,7 +70,9 @@ timestamps {
                         packagepipelineUtils.setDefaultEnvVars()
                         targetBranch = false
                         if (env.fed_request_1) {
-                            env.branch, env.fed_branch = packagepipelineUtils.setBuildBranch(env.request_1)
+                            branches = packagepipelineUtils.setBuildBranch(env.request_1)
+                            env.branch = branches[0]
+                            env.fed_branch = branches[1]
                             targetBranch = packagepipelineUtils.checkBranch(env.fed_branch)
                         }
                         // If the PR pipeline submit the build, let's just set targetBranch to false so we don't run

--- a/config/s2i/jenkins/master/configuration/scriptApproval.xml
+++ b/config/s2i/jenkins/master/configuration/scriptApproval.xml
@@ -8,6 +8,8 @@
     <string>staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains java.lang.Object[] java.lang.Object</string>
     <string>method groovy.json.JsonSlurperClassic parseText java.lang.String</string>
     <string>method java.lang.Class isInstance</string>
+    <string>method net.sf.json.JSONObject has java.lang.String</string>
+    <string>method net.sf.json.JSON isEmpty</string>
     <string>java.lang.Object</string>
     <string>new groovy.json.JsonSlurperClassic</string>
     <string>staticMethod java.lang.Class forName java.lang.String</string>

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -56,7 +56,7 @@ def setMessageFields(String messageType, String artifact, Map parsedMsg) {
         myRepo = parsedMsg['pullrequest']['project']['name']
         myRev = parsedMsg['pullrequest']['id']
         myNamespace = parsedMsg['pullrequest']['project']['namespace']
-        myCommentId = parsedMsg['pullrequest']['comments'].last()['id']
+        myCommentId = parsedMsg['pullrequest']['comments'].isEmpty() ? 0 : parsedMsg['pullrequest']['comments'].last()['id'].toInteger()
         myOwner = parsedMsg['pullrequest']['user']['name'].toString().split('\n')[0].replaceAll('"', '\'')
     } else {
         myBranch = env.fed_branch
@@ -87,7 +87,7 @@ def setMessageFields(String messageType, String artifact, Map parsedMsg) {
     ]
 
     if (artifact == 'pr') {
-        messageContent.commit_hash = env.fed_last_commit_hash
+        messageContent.commit_hash = parsedMsg['pullrequest'].has('commit_stop') ? parsedMsg['pullrequest']['commit_stop'] : 'N/A'
     }
 
     // Add image type to appropriate message types
@@ -159,10 +159,11 @@ def setTestMessageFields(String messageType, String artifact, Map parsedMsg) {
         myId = parsedMsg['pullrequest']['id']
         myUid = parsedMsg['pullrequest']['uid']
         myCommitHash = parsedMsg['pullrequest'].has('commit_stop') ? parsedMsg['pullrequest']['commit_stop'] : 'N/A'
-        myCommentId = parsedMsg['pullrequest'].has('comments') ? parsedMsg['pullrequest']['comments'].last()['id'].toInteger() : 0
+        myCommentId = parsedMsg['pullrequest']['comments'].isEmpty() ? 0 : parsedMsg['pullrequest']['comments'].last()['id'].toInteger()
         myType = 'build'
         myIssuer =  parsedMsg['pullrequest']['user']['name'].toString().split('\n')[0].replaceAll('"', '\'')
         myBranch = parsedMsg['pullrequest']['branch']
+        myRepository = "https://src.fedoraproject.org/" + parsedMsg['pullrequest']['project']['fullname']
 
         myArtifactContent = msgBusArtifactContent(type: 'pull-request', id: myId, issuer: myIssuer, repository: myRepository, commit_hash: myCommitHash, comment_id: myCommentId, uid: myUid)
         myTestContent = (messageType == "complete") ? msgBusTestContent(category: "static-analysis", namespace: myNamespace, type: "build", result: myResult) : msgBusTestContent(category: "static-analysis", namespace: myNamespace, type: "build")

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -245,7 +245,7 @@ def setDefaultEnvVars(Map envMap=null){
 /**
  * Library to set stage specific environmental variables.
  * @param stage - Current stage
- * @return
+ * @return map of vars
  */
 def setStageEnvVars(String stage){
     def stages =
@@ -289,7 +289,10 @@ def setStageEnvVars(String stage){
         stages.get(stage).each { key, value ->
             env."${key}" = value
         }
+        // Return map to pass to executeInContainer
+        return stages.get(stage)
     }
+    return null
 }
 
 /**

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -15,7 +15,7 @@ def setDistBranch(String branch) {
 
     if (branch != 'rawhide') {
         if (branch[0] == 'f') {
-            return = 'fc' + branch.substring(1)
+            return 'fc' + branch.substring(1)
         } else {
             throw new Exception("Invalid Branch Name ${branch}")
         }
@@ -51,7 +51,7 @@ def setMessageFields(String messageType, String artifact, Map parsedMsg) {
     // If something is applicable to only some subset of messages,
     // add it below per the existing examples.
 
-    if (parsedMsg.has('pullrequest') {
+    if (parsedMsg.has('pullrequest')) {
         myBranch = parsedMsg['pullrequest']['branch']
         myRepo = parsedMsg['pullrequest']['project']['name']
         myRev = parsedMsg['pullrequest']['id']
@@ -61,7 +61,7 @@ def setMessageFields(String messageType, String artifact, Map parsedMsg) {
     } else {
         myBranch = env.fed_branch
         myRepo = env.fed_repo
-        taskid = parsedMsg.has('task_id') ? parsedMsg['task_id'] ?: parsedMsg['info']['id']
+        taskid = parsedMsg.has('task_id') ? parsedMsg['task_id'] : parsedMsg['info']['id']
         myRev = 'kojitask-' + taskid
         myNamespace = env.fed_namespace
         myCommentId = ''
@@ -142,7 +142,7 @@ def setTestMessageFields(String messageType, String artifact, Map parsedMsg) {
 
     if (artifact == "koji-build") {
         // Set variables that go in multiple closures
-        myId = parsedMsg.has('task_id') ? parsedMsg['task_id'] ?: parsedMsg['info']['id']
+        myId = parsedMsg.has('task_id') ? parsedMsg['task_id'] : parsedMsg['info']['id']
         myScratch = env.isScratch.toBoolean()
         myNvr = env.nvr ?: 'N/A'
         myComponent = env.fed_repo

--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -444,3 +444,21 @@ def checkBranch(String branch) {
 
     return result
 }
+
+/**
+ * Function to set env.isScratch, env.request_0, and
+ * env.request_1 based on the parsedMsg key structure
+ * @param parsedMsg - The parsed fedmsg
+ * @return
+ */
+def setScratchVars(Map parsedMsg) {
+    if (parsedMsg.has('info')) {
+        env.isScratch = true
+        env.request_0 = parsedMsg['info']['request'][0]
+        env.request_1 = parsedMsg['info']['request'][1]
+    } else {
+        env.isScratch = false
+        env.request_0 = parsedMsg['request'][0]
+        env.request_1 = parsedMsg['request'][1]
+    }
+}

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -41,10 +41,11 @@ class packagepipelineUtils implements Serializable {
      * to create the ci.artifact.test.messageType messages
      * @param messageType: queued, running, complete, error
      * @param artifact: dist-git-pr, koji-build
+     * @param parsedMsg: The parsed fedmsg
      * @return
      */
-    def setTestMessageFields(String messageType, String artifact) {
-        packagePipelineUtils.setTestMessageFields(messageType, artifact)
+    def setTestMessageFields(String messageType, String artifact, Map parsedMsg) {
+        packagePipelineUtils.setTestMessageFields(messageType, artifact, parsedMsg)
     }
 
     /**

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -221,6 +221,18 @@ class packagepipelineUtils implements Serializable {
     }
 
     /**
+     * Library to send message
+     * @param msgTopic - The topic to send the message on
+     * @param msgProps - The message properties in key=value form, one key/value per line ending in '\n'
+     * @param msgContent - Message content
+     * @param provider - Provider to send message on. If not passed, will default to env.MSG_PROVIDER
+     * @return
+     */
+    def sendMessage(String msgTopic, String msgProps, String msgContent, def provider=null) {
+        contraUtils.sendMessage(msgTopic, msgProps, msgContent, provider)
+    }
+
+    /**
      * Function to set env.isScratch, env.request_0, and
      * env.request_1 based on the parsedMsg key structure
      * @param parsedMsg - The parsed fedmsg

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -219,4 +219,14 @@ class packagepipelineUtils implements Serializable {
         contraUtils.sendIRCNotification(nick, channel, message, ircServer)
     }
 
+    /**
+     * Function to set env.isScratch, env.request_0, and
+     * env.request_1 based on the parsedMsg key structure
+     * @param parsedMsg - The parsed fedmsg
+     * @return
+     */
+    def setScratchVars(Map parsedMsg) {
+        packagePipelineUtils.setScratchVars(parsedMsg)
+    }
+
 }

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -1,6 +1,7 @@
 import org.centos.pipeline.PackagePipelineUtils
 import org.centos.contra.pipeline.Utils
 import org.centos.Utils
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 /**
  * A class of methods used in the Jenkinsfile pipeline.
@@ -17,20 +18,22 @@ class packagepipelineUtils implements Serializable {
 
     /**
      * Method to to find DIST_BRANCH to use for rpm NVRs
+     * @param String branch - the branch value from the CI_MESSAGE
      * @return
      */
-    def setDistBranch() {
-        return packagePipelineUtils.setDistBranch()
+    def setDistBranch(String branch) {
+        return packagePipelineUtils.setDistBranch(branch)
     }
 
     /**
      * Method to set message fields to be published
      * @param messageType ${MAIN_TOPIC}.ci.pipeline.<defined-in-README>
      * @param artifact ${MAIN_TOPIC}.ci.pipeline.allpackages-${artifact}.<defined-in-README>
+     * @param parsedMsg: The parsed fedmsg
      * @return
      */
-    def setMessageFields(String messageType, String artifact) {
-        packagePipelineUtils.setMessageFields(messageType, artifact)
+    def setMessageFields(String messageType, String artifact, Map parsedMsg) {
+        packagePipelineUtils.setMessageFields(messageType, artifact, parsedMsg)
     }
 
     /**
@@ -101,11 +104,12 @@ class packagepipelineUtils implements Serializable {
     }
 
     /**
-     * Function to check if fed_branch is master or fXX, XX > 19
+     * Function to check if branch is master or fXX, XX > 19
+     * @param branch - The branch to check
      * @return bool
      */
-    def checkBranch() {
-        return packagePipelineUtils.checkBranch()
+    def checkBranch(String branch) {
+        return packagePipelineUtils.checkBranch(branch)
     }
 
     def influxDBPrefix() {
@@ -114,14 +118,16 @@ class packagepipelineUtils implements Serializable {
 
     /**
      * Test if $tag tests exist for $mypackage on $mybranch in fedora dist-git
-     * For mybranch, use fXX or master, or PR number (digits only)
+     * For mybranch, use fXX or master and pr_id is PR number (digits only)
      * @param mypackage
-     * @param mybranch - Fedora branch or PR number
+     * @param mybranch - Fedora branch
      * @param tag
+     * @param pr_id    - PR number
+     * @param namespace - rpms (default) or container
      * @return
      */
-    def checkTests(String mypackage, String mybranch, String tag) {
-        contraUtils.checkTests(mypackage, mybranch, tag)
+    def checkTests(String mypackage, String mybranch, String tag, String pr_id=null, String namespace='rpms') {
+        contraUtils.checkTests(mypackage, mybranch, tag, pr_id, namespace)
     }
 
     /**
@@ -149,7 +155,68 @@ class packagepipelineUtils implements Serializable {
      * @return
      */
     def setBuildBranch(String tag) {
-        contraUtils.setBuildBranch(tag)
+        return contraUtils.setBuildBranch(tag)
+    }
+
+    /**
+     * @param openshiftProject name of openshift namespace/project.
+     * @param nodeName podName we are going to get container logs from.
+     * @return
+     */
+    def getContainerLogsFromPod(String openshiftProject, String nodeName=env.NODE_NAME) {
+        contraUtils.getContainerLogsFromPod(openshiftProject, nodeName)
+    }
+
+    /**
+     * Mark stage stageName as skipped
+     * @param stageName
+     * @return
+     */
+    def skip(String stageName) {
+        org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional(stageName)
+    }
+
+    /**
+     * Method to prepend 'env.' to the keys in source file and write them in a format of env.key=value in the destination file.
+     * @param sourceFile The file to read from
+     * @param destinationFile The file to write to
+     */
+     def convertProps(String sourceFile, String destinationFile) {
+         centosUtils.convertProps(sourceFile, destinationFile)
+     }
+
+    /**
+     * Library to parse Pagure PR CI_MESSAGE and check if
+     * it is for a new commit added, the comment contains
+     * some keyword, or if the PR was rebased
+     * If notification = true, commit was added or it was rebased
+     * @param message - The CI_MESSAGE
+     * @param keyword - The keyword we care about
+     * @return bool
+     */
+    def checkUpdatedPR(String message, String keyword) {
+        return contraUtils.checkUpdatedPR(message, keyword)
+    }
+
+    /**
+     * Using the currentBuild, get a string representation
+     * of the changelog.
+     * @return String of changelog
+     */
+    def getChangeLogFromCurrentBuild() {
+        return contraUtils.getChangeLogFromCurrentBuild()
+    }
+
+    /**
+     *
+     * @param nick nickname to connect to IRC with
+     * @param channel channel to connect to
+     * @param message message to send
+     * @param ircServer optional IRC server defaults to irc.freenode.net:6697
+     * @return
+     */
+    def sendIRCNotification(String nick, String channel, String message, String ircServer="irc.freenode.net:6697") {
+        contraUtils.sendIRCNotification(nick, channel, message, ircServer)
     }
 
 }

--- a/vars/packagepipelineUtils.groovy
+++ b/vars/packagepipelineUtils.groovy
@@ -1,13 +1,16 @@
 import org.centos.pipeline.PackagePipelineUtils
+import org.centos.contra.pipeline.Utils
+import org.centos.Utils
 
 /**
  * A class of methods used in the Jenkinsfile pipeline.
- * These methods are wrappers around methods in the TODO library.
- * TODO - Find out how to libraies are going to be structured
+ * These methods are wrappers around methods in the packagepipelineUtils library.
  */
 class packagepipelineUtils implements Serializable {
 
     def packagePipelineUtils = new PackagePipelineUtils()
+    def contraUtils = new org.centos.contra.pipeline.Utils()
+    def centosUtils = new org.centos.Utils()
 
     // pass in from the jenkinsfile
     // def cimetrics
@@ -107,6 +110,46 @@ class packagepipelineUtils implements Serializable {
 
     def influxDBPrefix() {
         return "Fedora_All_Packages_Pipeline"
+    }
+
+    /**
+     * Test if $tag tests exist for $mypackage on $mybranch in fedora dist-git
+     * For mybranch, use fXX or master, or PR number (digits only)
+     * @param mypackage
+     * @param mybranch - Fedora branch or PR number
+     * @param tag
+     * @return
+     */
+    def checkTests(String mypackage, String mybranch, String tag) {
+        contraUtils.checkTests(mypackage, mybranch, tag)
+    }
+
+    /**
+     *
+     * @param openshiftProject name of openshift namespace/project.
+     * @param nodeName podName we are going to verify.
+     * @return
+     */
+    def verifyPod(String openshiftProject, String nodeName=env.NODE_NAME) {
+        contraUtils.verifyPod(openshiftProject, nodeName)
+    }
+
+    /**
+     * @param request - the url that refers to the package
+     * @return
+     */
+    def repoFromRequest(String request) {
+        contraUtils.repoFromRequest(request)
+    }
+
+    /**
+     * Set branch and repo_branch based on the candidate branch
+     * This is meant to be run with a CI_MESSAGE from a build task
+     * @param tag - The tag from the request field e.g. f27-candidate
+     * @return
+     */
+    def setBuildBranch(String tag) {
+        contraUtils.setBuildBranch(tag)
     }
 
 }


### PR DESCRIPTION
Remove pipelineUtils functions from this repo so this repo is not dependent on the shared library located in ci-pipeline. 

I still have to finish up ContainerBuildTrigger, ContainerTaskTrigger, and ContainerJenkinsfile before merging, but I figured I'd open the PR now so you can start reviewing the standard workflow parts.

This will make rebasing the updated message spec PR a pain, but I probably have a bit of time to do that since we are waiting on resultsDB to be updated =)