### PR TITLE
add support to results.yml

### DIFF
--- a/ContainerJenkinsfile
+++ b/ContainerJenkinsfile
@@ -219,6 +219,23 @@ spec:
                                         }
                                     }
 
+                                    if (pipelineUtils.fileExists("${WORKSPACE}/${currentStage}/logs/results.yml")) {
+                                        def test_results = readYaml file: "${WORKSPACE}/${currentStage}/logs/results.yml"
+                                        def test_failed = false
+                                        test_results['results'].each { result ->
+                                            // some test case exited with error
+                                            if (result.result == "error") {
+                                                 throw new Exception("FAIL: test ${result.test} exited with error")
+                                            }
+                                            if (result.result == "fail") {
+                                                test_failed = true
+                                            }
+                                        }
+                                        if (test_failed) {
+                                            currentBuild.result = 'UNSTABLE'
+                                        }
+                                    }
+
                                     // Set our message topic, properties, and content
                                     messageFields = packagepipelineUtils.setMessageFields("container.test.functional.complete", artifact)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -385,6 +385,23 @@ timestamps {
                                         }
                                     }
 
+                                    if (pipelineUtils.fileExists("${WORKSPACE}/${currentStage}/logs/results.yml")) {
+                                        def test_results = readYaml file: "${WORKSPACE}/${currentStage}/logs/results.yml"
+                                        def test_failed = false
+                                        test_results['results'].each { result ->
+                                            // some test case exited with error
+                                            if (result.result == "error") {
+                                                 throw new Exception("FAIL: test ${result.test} exited with error")
+                                            }
+                                            if (result.result == "fail") {
+                                                test_failed = true
+                                            }
+                                        }
+                                        if (test_failed) {
+                                            currentBuild.result = 'UNSTABLE'
+                                        }
+                                    }
+
                                     // Set our message topic, properties, and content
                                     messageFields = packagepipelineUtils.setMessageFields("package.test.functional.complete", artifact)
 


### PR DESCRIPTION
standard-test-interface from v2.0.0 defines support to results.yml [1]

new standard-test-roles builds will follow new STI standard.

This PR is for the pipeline to be able to handle new STR builds.

[1] https://docs.fedoraproject.org/en-US/ci/standard-test-interface/#_results_format