### PR TITLE
Add fonts-rpm-macros package into fedoraci-runner

### DIFF
--- a/config/Dockerfiles/fedoraci-runner/Dockerfile
+++ b/config/Dockerfiles/fedoraci-runner/Dockerfile
@@ -16,6 +16,7 @@ RUN for i in {1..5} ; do dnf -y install \
         fedpkg \
         file \
         findutils \
+        fonts-rpm-macros \
         git \
         koji \
         krb5-workstation \


### PR DESCRIPTION
Add fonts-rpm-macros package into fedoraci-runner to add missing %fontpkg macro per https://pagure.io/fedora-ci/general/issue/99 