### PR TITLE
uses python3 when testing compose

### DIFF
--- a/src/org/centos/pipeline/PackagePipelineUtils.groovy
+++ b/src/org/centos/pipeline/PackagePipelineUtils.groovy
@@ -684,7 +684,7 @@ def testCompose(Map parameters = [:]) {
     def cmd = """
               curl -O https://pagure.io/upstream-fedora-ci/raw/master/f/validate-test-subject.py && \
               rm -rf /tmp/artifacts && \
-              python -u validate-test-subject.py -i ${interactions} -s \$(pwd)/${imageName} && \
+              python3 -u validate-test-subject.py -i ${interactions} -s \$(pwd)/${imageName} && \
               exit \$?
               """
 


### PR DESCRIPTION
Our test runner is Fedora-31 that doesn't ship python2 any more, we should run the script that validates the compose using python3.