### PR TITLE
Rollback this trigger while troubleshooting

### DIFF
--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -35,7 +35,6 @@ timestamps {
                                   name: 'fedora-fedmsg',
                                   overrides: [
                                       topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
-                                      queue: ''
                                   ]
                               ]
                             ]]

--- a/JenkinsfileBuildTrigger
+++ b/JenkinsfileBuildTrigger
@@ -31,8 +31,8 @@ timestamps {
                             [[$class: 'CIBuildTrigger',
                               noSquash: true,
                               providerData: [
-                                  $class: 'RabbitMQSubscriberProviderData',
-                                  name: 'FedoraMessaging',
+                                  $class: 'FedMsgSubscriberProviderData',
+                                  name: 'fedora-fedmsg',
                                   overrides: [
                                       topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
                                       queue: ''

--- a/config/s2i/jenkins/master/configuration/jobs/fedora-task-pipeline-trigger/config.xml
+++ b/config/s2i/jenkins/master/configuration/jobs/fedora-task-pipeline-trigger/config.xml
@@ -46,8 +46,8 @@
                 <com.redhat.jenkins.plugins.ci.CIBuildTrigger plugin="jms-messaging@1.1.5">
                    <spec />
                    <noSquash>true</noSquash>
-                   <providerData class="com.redhat.jenkins.plugins.ci.provider.data.RabbitMQSubscriberProviderData">
-                      <name>FedoraMessaging</name>
+                   <providerData class="com.redhat.jenkins.plugins.ci.provider.data.FedMsgSubscriberProviderData">
+                      <name>fedora-fedmsg</name>
                       <overrides>
                          <topic>org.fedoraproject.prod.buildsys.task.state.change</topic>
                       </overrides>


### PR DESCRIPTION
https://jenkins-continuous-infra.apps.ci.centos.org/view/Fedora%20All%20Packages%20Pipeline/job/fedora-build-pipeline-trigger/

When switching to Fedora Messaing, we're triggering on the wrong topics. 

https://jenkins-continuous-infra.apps.ci.centos.org/view/Fedora%20All%20Packages%20Pipeline/job/fedora-build-pipeline-trigger/448285/parameters/

This rolls it back while we troubleshoot.